### PR TITLE
feature: android 13 camera fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surikat-cordova-plugin-camera",
-  "version": "6.0.2-dev",
+  "version": "6.0.3-dev",
   "description": "Cordova Camera Plugin",
   "types": "./types/index.d.ts",
   "cordova": {


### PR DESCRIPTION
### Tested on versions
- [X] Android 13
- [X] Android 12
- [x] Android 11
- [x] Android 10
- [x] Android 9
- [x] Android 8
- [X] Android 7

# Changes
* Changed `CameraLauncher.java`, it was before just asking for `WRITE_EXTERNAL_STORAGE` & `READ_EXTERNAL_STORAGE` which isn't supported anymore for android 13, and made statements checking what android version we are to give correct permission.

# Resources
* https://developer.android.com/about/versions/13/behavior-changes-13#granular-media-permissions